### PR TITLE
added sample codes to demonstrate the use of API:Links module to identify red links on the given page

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -366,5 +366,18 @@
             "list": "usercontribs",
             "ucuser": "Jimbo Wales"
     	}
+    },
+    {
+
+        "filename": "get_red_links.py",
+        "docstring": "Demo of `Links` module: Use module as a generator\n\tto get all links on a given page(s)\n\tand identify if the link is a red link or not",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "format": "json",
+            "prop": "links",
+            "titles": "Title",
+            "generator": "links"
+        }
     }
 ]

--- a/python/get_red_links.py
+++ b/python/get_red_links.py
@@ -1,0 +1,33 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    get_red_links.py
+
+    MediaWiki Action API Code Samples
+    Demo of `Links` module: Use generator module
+    to get all links on the given page(s)
+    and identify if the link is a red link or not
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "query",
+    "format": "json",
+    "prop": "links",
+    "titles": "Title",
+    "generator": "links"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
According to this [link](https://en.wikipedia.org/wiki/Help:Link_color ), a red link is a link to a page that does not currently exist within Wikipedia. 
Following this [discussion](https://discourse-mediawiki.wmflabs.org/t/data-returned-by-the-query-api-does-not-say-if-a-link-is-a-red-link-or-not/1043), red links are identified by **negative numbers** example(-1,-2,etc) and a **missing** statement. 

The documentation for the [API:Link](https://www.mediawiki.org/wiki/API:Links) module states that the module can be used as a generator and because it possesses this attribute, it can generate all the links to a given page(red or not). 

The **generator=links** displays all the data on which linked titles are missing for a given title(page) thereby also including the red links.

In this sample code, I used the English Wikipedia's page on [Title](https://en.wikipedia.org/wiki/Title)

Kindly review @srish 
