### PR TITLE
API:Links sample code to get red links in a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   *  [get_filtered_page_revisions.py](python/get_filtered_page_revisions.py): get revision data of a page filtered by date and user
 * [API:Links](https://www.mediawiki.org/wiki/API:Links)
   *  [get_links.py](python/get_links.py): get links embedded on a page
+  *  [get_red_links.py](python/get_red_links.py): get the first twenty red links in a page
 * [API:Info](https://www.mediawiki.org/wiki/API:Info)
   * [get_info.py](python/get_info.py): get basic information about a page
 * [API:Allpages](https://www.mediawiki.org/wiki/API:Allpages)

--- a/modules.json
+++ b/modules.json
@@ -376,8 +376,8 @@
             "action": "query",
             "format": "json",
             "generator": "links",
-		    "titles": "Wikipedia:Most-wanted_articles",
-		    "gpllimit": "20"
+            "titles": "Wikipedia:Most-wanted_articles",
+            "gpllimit": "20"
         }
     }
 ]

--- a/modules.json
+++ b/modules.json
@@ -366,5 +366,18 @@
             "list": "usercontribs",
             "ucuser": "Jimbo Wales"
     	}
+
+    },
+    {
+        "filename": "get_red_links.py",
+        "docstring": "Demo of `Links` module: List red links in a page.",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "format": "json",
+            "generator": "links",
+		    "titles": "Wikipedia:Most-wanted_articles",
+		    "gpllimit": "20"
+        }
     }
 ]

--- a/python/get_red_links.py
+++ b/python/get_red_links.py
@@ -1,0 +1,38 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    get_red_links.py
+
+    MediaWiki Action API Code Samples
+    Demo of `Links` module: List red links in a page.
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "query",
+    "titles": "Wikipedia:Most-wanted_articles",
+    "gpllimit": "20",
+    "format": "json",
+    "generator": "links"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+pages = DATA['query']['pages']
+missing_pages = {}
+
+for page in pages:
+	if int(page) < 0:
+		missing_page = pages[page]
+		missing_pages.update({page:missing_page})
+
+print(missing_pages)

--- a/python/get_red_links.py
+++ b/python/get_red_links.py
@@ -27,12 +27,11 @@ PARAMS = {
 
 R = S.get(url=URL, params=PARAMS)
 DATA = R.json()
-pages = DATA['query']['pages']
-missing_pages = {}
+PAGES = DATA['query']['pages']
+MISSING_PAGES = []
 
-for page in pages:
-	if int(page) < 0:
-		missing_page = pages[page]
-		missing_pages.update({page:missing_page})
+for page in PAGES:
+    if int(page) < 0:
+        MISSING_PAGES.append(PAGES[page]['title'])
 
-print(missing_pages)
+print(MISSING_PAGES)


### PR DESCRIPTION
Sample code to demonstrate the use of API:Links module to identify red links on a page.
Based on #37

