### PR TITLE
Sample code for API:RecentChanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [watch.py](python/watch.py): add a page to your watchlist 
 * [API:Alllinks](https://www.mediawiki.org/wiki/API:Alllinks)
   * [get_alllinks.py](python/get_alllinks.py): list links to a namespace
+* [API:RecentChanges](https://www.mediawiki.org/wiki/API:RecentChanges)
+  * [get_recent_changes.py](python/get_recent_changes.py): get the three most recent changes with sizes and flags
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/modules.json
+++ b/modules.json
@@ -366,5 +366,18 @@
             "list": "usercontribs",
             "ucuser": "Jimbo Wales"
     	}
+
+    },
+    {
+        "filename": "get_recent_changes.py",
+        "docstring": "Demo of `RecentChanges` module: Get the three most recent changes with sizes and flags",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "format": "json",
+            "list": "recentchanges",
+            "rcprop": "title|ids|sizes|flags|user",
+            "rclimit": "3"
+        }
     }
 ]

--- a/python/get_recent_changes.py
+++ b/python/get_recent_changes.py
@@ -1,0 +1,31 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    get_recent_changes.py
+
+    MediaWiki Action API Code Samples
+    Demo of `RecentChanges` module: Get the three most recent changes with sizes and flags
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "format": "json",
+    "rcprop": "title|ids|sizes|flags|user",
+    "list": "recentchanges",
+    "action": "query",
+    "rclimit": "3"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
Sample code for API:RecentChanges module to get the three most recent changes with sizes and flags.