### PR TITLE
Added sample codes for API:Embeddedin

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [watch.py](python/watch.py): add a page to your watchlist 
 * [API:Alllinks](https://www.mediawiki.org/wiki/API:Alllinks)
   * [get_alllinks.py](python/get_alllinks.py): list links to a namespace
+* [API:Embeddedin](https://www.mediawiki.org/wiki/API:Embeddedin)
+  * [get_embedded_pages.py](python/get_embedded_pages.py): get all page(s) that embed the given title
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/modules.json
+++ b/modules.json
@@ -379,5 +379,17 @@
             "titles": "Wikipedia:Most-wanted_articles",
             "gpllimit": "20"
         }
+    },
+    {
+        "filename": "get_embedded_pages.py",
+        "docstring": "Demo of `Embeddedin` module: Get all page(s) that embed the given title.",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "format": "json",
+            "list": "embeddedin",
+            "eititle": "Computer",
+            "eilimit": "20"
+        }
     }
 ]

--- a/python/get_embedded_pages.py
+++ b/python/get_embedded_pages.py
@@ -1,0 +1,31 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    get_embedded_lists.py
+    MediaWiki Action API Code Samples
+    Demo of `Embeddedin` module: Get all page(s) that
+    embed the given title.
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "query",
+    "format": "json",
+    "list": "embeddedin",
+    "eititle": "Computer",
+    "eilimit": "20"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
API:Embeddedin gets a list of all page(s) that embed (transclude) the given title. 
My sample code displays all pages that embed the English Wikipedia's page on [w:Computer](https://en.wikipedia.org/wiki/Computer).
1) I have added the Get requests params to  modules.json.
2) The file is auto generated.
3) I ran my codes through pylint and it passed all the Pylint tests.
4) Added code and page description to  README.md 
This is the [link](https://www.mediawiki.org/wiki/User:Didicodes/Sandbox/API:Embeddedin) to the sandbox page I created for this API
Kindly review @srish 