### PR TITLE
API:Rollback Sample Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [watch.py](python/watch.py): add a page to your watchlist 
 * [API:Alllinks](https://www.mediawiki.org/wiki/API:Alllinks)
   * [get_alllinks.py](python/get_alllinks.py): list links to a namespace
+* [API:Rollback](https://www.mediawiki.org/wiki/API:Rollback)
+  * [rollback.py](python/rollback.py): roll back the last edits made to the given page
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/python/rollback.py
+++ b/python/rollback.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python3
+
+"""
+    rollback.py
+
+    MediaWiki Action API Code Samples
+    Demo of `rollback` module: Sending post request to roll
+    back the last edits made to the given page.
+
+    MIT license
+"""
+import requests
+
+S = requests.Session()
+
+URL = "https://test.wikipedia.org/w/api.php"
+
+# Step 1: Retrieve a login token
+PARAMS_1 = {
+    "action": "query",
+    "meta": "tokens",
+    "type": "login",
+    "format": "json"
+}
+
+R = S.get(url=URL, params=PARAMS_1)
+DATA = R.json()
+
+LOGIN_TOKEN = DATA['query']['tokens']['logintoken']
+
+# Step2: Send a post request to login. Use of main account for login is not
+# supported. Obtain credentials via Special:BotPasswords
+# (https://www.mediawiki.org/wiki/Special:BotPasswords) for lgname & lgpassword
+PARAMS_2 = {
+    "action": "login",
+    "lgname": "bot_user_name",
+    "lgpassword": "bot_password",
+    "lgtoken": LOGIN_TOKEN,
+    "format": "json"
+}
+
+R = S.post(URL, data=PARAMS_2)
+
+# Step 3: While logged in, retrieve a CSRF token
+PARAMS_3 = {
+    "action": "query",
+    "meta": "tokens",
+    "format": "json"
+}
+
+R = S.get(url=URL, params=PARAMS_3)
+DATA = R.json()
+
+CSRF_TOKEN = DATA["query"]["tokens"]["csrftoken"]
+
+# Step 4: POST request to edit a page
+PARAMS_4 = {
+    "action": "edit",
+    "title": "Sandbox",
+    "token": CSRF_TOKEN,
+    "format": "json",
+    "appendtext": "Hello"
+}
+
+R = S.post(URL, data=PARAMS_4)
+
+# Step 5: Retrieve a rollback token
+PARAMS_5 = {
+    "action": "query",
+    "meta": "tokens",
+    "type": "rollback",
+    "format": "json"
+}
+
+R = S.get(url=URL, params=PARAMS_5)
+DATA = R.json()
+
+ROLLBACK_TOKEN = DATA['query']['tokens']['rollbacktoken']
+
+# Step 5: POST request to rollback a page
+PARAMS_6 = {
+    "action": "rollback",
+    "format": "json",
+    "title": "Sandbox",
+    "user": "41.190.3.231",
+    "token": ROLLBACK_TOKEN,
+}
+
+R = S.post(URL, data=PARAMS_6)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
Rolling back a page means undoing the last edits made to that page by a particular user.
API:Rollback requires both Editpage and Rollback right on the target page. According to the documentation of API:Edit, before any page can be edited, the user has to be logged in, so I had to do the following in order to rollback a Sandbox page.
1) Retrieved a login token
2) Made a post request to login
3) While logged in, retrieved a CSRF token
4) Made a POST request to edit a page 
5) Retrieved a rollback token
6) Made a POST request to rollback the sandbox page
7) Pylint fixes.
However, rolling back a page is limited to users in one of the groups: [[Wikipedia:Administrators|Administrators]], [[Wikipedia:Rollbackers|Rollbackers]]. I asked a [question](https://discourse-mediawiki.wmflabs.org/t/error-permissiondenied-to-rollback-edits-made-to-a-page-api-rollback/1197/4) about this error on the Wikimedia forum and @tgr answered my questions and also added me to the rollbackers group. With this, I was able to roll back a page using the Wikipedia test site [here](https://test.wikipedia.org/wiki/Special:ApiSandbox#action=rollback&format=json&title=Sandbox&user=41.190.3.231&token=d36a517a732991d5aaafae8bd40eee4a5c7bf75a%2B%5C). See picture below for clarification 
![screenshot 676](https://user-images.githubusercontent.com/28895379/53698346-abbe0500-3ddb-11e9-82dd-91d219ac4901.png) When I tried to run the codes on my command prompt, I wasnt able to rollback a page because I wasnt granted the right. I believe this happened because of the Login Botpassword authentication method used in the sample codes. If a user uses the ClientLogin authentication method  and has also be added to the rollbackers group, then he or she would actually be able to rollback a page. 
This is the link to my [sandox page](https://www.mediawiki.org/wiki/User:Didicodes/Sandbox/API:Rollback) containing the imporved documentation for API:Rollback.
Kindly review @srish 
