### PR TITLE
API:Protect  & API:Langlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [login.py](python/login.py) & [clientlogin.py](python/clientlogin.py): login
 * [API:Logout](https://www.mediawiki.org/wiki/API:Logout)
   * [logout.py](python/logout.py): logout
+* [API:Protect](https://www.mediawiki.org/wiki/API:Protect)
+  * [protect.py](python/protect.py): Change the protection level of a given page.
 
 ### Accounts and users 
 * [API:Account creation](https://www.mediawiki.org/wiki/API:Account_creation)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [watch.py](python/watch.py): add a page to your watchlist 
 * [API:Alllinks](https://www.mediawiki.org/wiki/API:Alllinks)
   * [get_alllinks.py](python/get_alllinks.py): list links to a namespace
+* [API:Langlinks](https://www.mediawiki.org/wiki/API:Langlinks)
+  * [get_langlinks.py](python/get_langlinks.py): Gets a list of all language links from the provided pages to other languages.
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/modules.json
+++ b/modules.json
@@ -366,5 +366,18 @@
             "list": "usercontribs",
             "ucuser": "Jimbo Wales"
     	}
+    },
+    {
+        "filename": "protect.py",
+        "docstring": "Demo of `Protect` module: Demo to change the edit protection level of a given page.",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+                "action": "protect",
+    		"title": "Main Page",
+    		"edit": "autoconfirmed",
+    		"move": "sysop",
+    		"expiry" : "infinite",
+    		"token" : ""
+    	}
     }
 ]

--- a/modules.json
+++ b/modules.json
@@ -372,12 +372,25 @@
         "docstring": "Demo of `Protect` module: Demo to change the edit protection level of a given page.",
         "endpoint": "https://en.wikipedia.org/w/api.php",
         "params": {
-                "action": "protect",
-    		"title": "Main Page",
-    		"edit": "autoconfirmed",
-    		"move": "sysop",
+                "action" : "protect",
+    		"title"  : "Main Page",
+    		"edit"   : "autoconfirmed",
+    		"move"   : "sysop",
     		"expiry" : "infinite",
-    		"token" : ""
+    		"token"  : ""
+    	}
+    },
+    {
+        "filename": "get_langlinks.py",
+        "docstring": "Demo of `Langlinks` module: Demo to gets a list of first 20 language links from the provided pages to other languages.",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+                "action" : "query",
+    		"format" : "json",
+    		"titles" : "Main Page",
+    		"prop"   : "langlinks",
+    		"lllimit": "20",
+    		"llprop" : "langname"
     	}
     }
 ]

--- a/python/get_langlinks.py
+++ b/python/get_langlinks.py
@@ -17,7 +17,7 @@ S = requests.Session()
 
 URL = "https://en.wikipedia.org/w/api.php"
 
-#list of first 20 lanuage links with the localised language name.
+#list of first 20 language links with the localised language name.
 
 PARAMS = {
     "llprop" : "langname",

--- a/python/get_langlinks.py
+++ b/python/get_langlinks.py
@@ -1,0 +1,34 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    get_langlinks.py
+
+    MediaWiki Action API Code Samples
+    Demo of `Langlinks` module: Demo to gets a list of first 20 language links from the provided pages to other languages.
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+#list of first 20 lanuage links with the localised language name.
+
+PARAMS = {
+    "llprop" : "langname",
+    "format" : "json",
+    "lllimit": "20",
+    "prop"   : "langlinks",
+    "titles" : "Main Page",
+    "action" : "query"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)

--- a/python/protect.py
+++ b/python/protect.py
@@ -16,27 +16,27 @@ import requests
 S = requests.Session()
 
 URL = "https://en.wikipedia.org/w/api.php"
-
-# Step 1: Retrieve a login token using GET request
+# To change a page's protection level, a CSRF token is required. 
+# Step 1: Retrieve a CSRF token using GET request
 PARAMS_1 = {
     "action": "query",
     "meta": "tokens",
-    "type": "login",
+    "type": "csrf",
     "format": "json"
 }
 
 R = S.get(url=URL, params=PARAMS_1)
 DATA = R.json()
 
-LOGIN_TOKEN = DATA["query"]["tokens"]["logintoken"]
+CSRF_TOKEN = DATA["query"]["tokens"]["csrftoken"]
 
-# Step 1: Changing edit protection level of a page using POST request
+# Step 2: Changing 'edit protection level' of a page using POST request
 PARAMS = {
     "title": "Main Page",
     "edit": "autoconfirmed",
     "move": "sysop",
     "expiry": "infinite",
-    "token": LOGIN_TOKEN,
+    "token": CSRF_TOKEN,
     "action": "protect"
 }
 

--- a/python/protect.py
+++ b/python/protect.py
@@ -1,0 +1,43 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    protect.py
+
+    MediaWiki Action API Code Samples
+    Demo of `Protect` module: Demo to change the edit protection level of a given page.
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+# Step 1: Retrieve a login token using GET request
+PARAMS_1 = {
+    "action": "query",
+    "meta": "tokens",
+    "type": "login",
+    "format": "json"
+}
+
+R = S.get(url=URL, params=PARAMS_1)
+DATA = R.json()
+
+LOGIN_TOKEN = DATA["query"]["tokens"]["logintoken"]
+
+# Step 1: Changing edit protection level of a page using POST request
+PARAMS = {
+    "title": "Main Page",
+    "edit": "autoconfirmed",
+    "move": "sysop",
+    "expiry": "infinite",
+    "token": LOGIN_TOKEN,
+    "action": "protect"
+}
+
+R = S.post(url=URL, params=PARAMS)


### PR DESCRIPTION
Demo of `Protect` module: Demo to change the 'edit protection level' of a given page.
I have changed following files:

Demo of `Langlinks` module : Demo to gets a list of first 20 language links from the provided pages to other languages.

README.md
modules.json
python/protect.py
python/get_langlinks.py

`Protect` module: To change a page's protection level, token is required. Following are steps I followed to change page edit protection level.
step 1 : Retrieved a CSRF token by get request using API:Tokens with type=csrf
step 2 : Made a POST request to change a page 'edit protection level'

`Langlinks` module: GET request to list of first 20 language links with the localised language name.

@srish Plaese review. Thanks.! :)