### PR TITLE
Add sample code for API:Compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   *  [set_page_language.py](python/set_page_language.py): change page language
 * [API:Embeddedin](https://www.mediawiki.org/wiki/API:Embeddedin)
   * [get_embedded_pages.py](python/get_embedded_pages.py): get all page(s) that embed a page
+* [API:Compare](https://www.mediawiki.org/wiki/API:Compare)
+  * [compare_page_revisions.py](python/compare_page_revisions.py): Compare two revisions from the same page
+  * [compare_pages.py](python/compare_pages.py): Compare the current revisions of two different pages
+  * [compare_page_with_text.py](python/compare_page_with_text.py): Compare a revision of a page to some text
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/modules.json
+++ b/modules.json
@@ -416,5 +416,38 @@
             "list": "exturlusage",
             "euquery": "slashdot.org"
     	}
-    }
+    },
+	{
+		"filename": "compare_page_revisions",
+        "docstring": "Demo of `Compare` module: Compare two revisions from the same page",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "compare",
+            "format": "json",
+            "fromrev": "139992",
+            "torev": "139993"
+        }
+	},
+	{
+		"filename": "compare_pages",
+        "docstring": "Demo of `Compare` module: Compare the current revisions of two different pages",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "compare",
+            "format": "json",
+			"fromtitle": "Template:Unsigned",
+			"totitle": "Template:UnsignedIP"
+		}
+	},
+	{
+		"filename": "compare_page_with_text",
+        "docstring": "Demo of `Compare` module: Compare a revision of a page to some text",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "compare",
+            "format": "json",
+			"fromrev": "829678781",
+			"totext": "test%20edit,%20please%20ignore"
+		}
+	}
 ]

--- a/python/compare_page_revisions.py
+++ b/python/compare_page_revisions.py
@@ -1,0 +1,29 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    compare_page_revisions.py
+
+    MediaWiki Action API Code Samples
+    Demo of `Compare` module: Compare two revisions from the same page
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "compare",
+    "format": "json",
+    "fromrev": "139992",
+    "torev": "139993"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)

--- a/python/compare_page_with_text.py
+++ b/python/compare_page_with_text.py
@@ -1,0 +1,29 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    compare_page_with_text.py
+
+    MediaWiki Action API Code Samples
+    Demo of `Compare` module: Compare a revision of a page to some text
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "compare",
+    "format": "json",
+    "fromrev": "829678781",
+    "totext": "test%20edit,%20please%20ignore"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)

--- a/python/compare_pages.py
+++ b/python/compare_pages.py
@@ -1,0 +1,29 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    compare_pages.py
+
+    MediaWiki Action API Code Samples
+    Demo of `Compare` module: Compare the current revisions of two different pages
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "compare",
+    "format": "json",
+    "fromtitle": "Template:Unsigned",
+    "totitle": "Template:UnsignedIP"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
 Sample code for API:Compare.
Added code compare_page_revisions.py, compare_pages.py & compare_page_with_text.py .
I have created code samples docs into my sandbox. link https://www.mediawiki.org/wiki/User:Adarshpatel509/Sandbox/Compare
@srish Please review this. Thanks.