### PR TITLE
Fix mediawiki.org url

### DIFF
--- a/javascript/get_filtered_page_revisions.js
+++ b/javascript/get_filtered_page_revisions.js
@@ -9,7 +9,7 @@
     MIT License
 */
 
-var url = "https://mediawiki.org/w/api.php"; 
+var url = "https://www.mediawiki.org/w/api.php";
 
 var params = {
     action: "query",

--- a/javascript/get_pages_revisions.js
+++ b/javascript/get_pages_revisions.js
@@ -9,7 +9,7 @@
     MIT License
 */
 
-var url = "https://mediawiki.org/w/api.php"; 
+var url = "https://www.mediawiki.org/w/api.php";
 
 var params = {
     action: "query",

--- a/javascript/tokens.js
+++ b/javascript/tokens.js
@@ -9,7 +9,7 @@
     MIT License
 */
 
-var url = "https://mediawiki.org/w/api.php"; 
+var url = "https://www.mediawiki.org/w/api.php";
 
 var params = {
     action: "query",

--- a/modules.json
+++ b/modules.json
@@ -2,7 +2,7 @@
 	{
 		"filename": "tokens",
 		"docstring": "Demo of `Token` module: Fetch token of type `login`",
-		"endpoint": "https://mediawiki.org/w/api.php",
+		"endpoint": "https://www.mediawiki.org/w/api.php",
 		"params": {
 			"action": "query",
 			"meta": "tokens",
@@ -188,7 +188,7 @@
 	{
 		"filename": "get_pages_revisions",
 		"docstring": "Demo of `Revisions` module: Get revision data with content for pages with titles [[API]] and [[Main Page]]",
-		"endpoint": "https://mediawiki.org/w/api.php",
+		"endpoint": "https://www.mediawiki.org/w/api.php",
 		"params": {
 			"action": "query",
 			"prop": "revisions",
@@ -202,7 +202,7 @@
 	{
 		"filename": "get_filtered_page_revisions",
 		"docstring": "Demo of `Revisions` module: Get data including content of last 5 revisions of the title [[API:Geosearch]] made after July 1st 2018 excluding changes made by the user SSethi (WMF)",
-		"endpoint": "https://mediawiki.org/w/api.php",
+		"endpoint": "https://www.mediawiki.org/w/api.php",
 		"params": {
 			"action": "query",
 			"prop": "revisions",

--- a/python/get_filtered_page_revisions.py
+++ b/python/get_filtered_page_revisions.py
@@ -17,7 +17,7 @@ import requests
 
 S = requests.Session()
 
-URL = "https://mediawiki.org/w/api.php"
+URL = "https://www.mediawiki.org/w/api.php"
 
 PARAMS = {
     "action": "query",

--- a/python/get_pages_revisions.py
+++ b/python/get_pages_revisions.py
@@ -16,7 +16,7 @@ import requests
 
 S = requests.Session()
 
-URL = "https://mediawiki.org/w/api.php"
+URL = "https://www.mediawiki.org/w/api.php"
 
 PARAMS = {
     "action": "query",

--- a/python/login.py
+++ b/python/login.py
@@ -12,7 +12,7 @@ import requests
 
 S = requests.Session()
 
-URL = "https://mediawiki.org/w/api.php"
+URL = "https://www.mediawiki.org/w/api.php"
 
 # Retrieve login token first
 PARAMS_0 = {

--- a/python/tokens.py
+++ b/python/tokens.py
@@ -15,7 +15,7 @@ import requests
 
 S = requests.Session()
 
-URL = "https://mediawiki.org/w/api.php"
+URL = "https://www.mediawiki.org/w/api.php"
 
 PARAMS = {
     "action": "query",


### PR DESCRIPTION
Currently in some files "https://mediawiki.org" used
as the url endpoint instead of "https://www.mediawiki.org".

Current url is ok with python, But it is incomparable
with PHP. I have tested it. It return NULL.

See:-
```
Jay-Prakash:python $ curl -I "https://mediawiki.org/w/api.php"
HTTP/1.1 301 Moved Permanently
```
and
```
Jay-Prakash:python $ curl -I "https://www.mediawiki.org/w/api.php"
HTTP/1.1 200 OK
```